### PR TITLE
[MAINT] drop python 3.8 and support 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         strategy:
             matrix:
                 os: [macos-latest, ubuntu-latest, windows-latest]
-                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
             fail-fast: false
 
         steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v3.17.0
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 
 -   repo: https://github.com/psf/black
     rev: 24.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Unix",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
     "cffconvert",
@@ -36,7 +36,7 @@ license = {text = "LGPL-3.0"}
 maintainers = [{name = "Rémi Gau", email = "remi.gau@gmail.com"}]
 name = "bids2cite"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary by Sourcery

Drop support for Python 3.8 and add support for Python 3.13 in the CI workflow and pre-commit configuration.

Build:
- Modify pre-commit configuration to require Python 3.9 or newer for the pyupgrade hook.

CI:
- Update the CI workflow to drop support for Python 3.8 and add support for Python 3.13.